### PR TITLE
Adding firewall_dns_info() and the ability to set a hostname as source/destination

### DIFF
--- a/lib/puppet/parser/functions/firewall_dns_info.rb
+++ b/lib/puppet/parser/functions/firewall_dns_info.rb
@@ -1,0 +1,22 @@
+
+module Puppet::Parser::Functions
+  newfunction(:firewall_dns_info, :type => :rvalue, :doc => <<-EOS
+Lookup a hostname (both IPv4 and IPv6) and return its ip addresses
+    EOS
+  ) do |vals|
+    hostname = vals[0]
+    raise(ArgumentError, 'Must specify a hostname') unless hostname
+    
+    Puppet::Parser::Functions.function(:nslookup)
+    
+    out = {
+      'ip_v4' => function_nslookup([ hostname, 'A'   ]),
+      'ip_v6' => function_nslookup([ hostname, 'AAAA'])
+    }
+    
+    out['enable_v4'] = out['ip_v4'].length > 0
+    out['enable_v6'] = out['ip_v6'].length > 0
+
+    return out
+  end
+end

--- a/lib/puppet/parser/functions/firewall_resolve_locations.rb
+++ b/lib/puppet/parser/functions/firewall_resolve_locations.rb
@@ -1,0 +1,35 @@
+
+
+module Puppet::Parser::Functions
+  newfunction(:firewall_resolve_locations, :type => :rvalue, :doc => <<-EOS
+Resolve an array containing IP's and hostnames to hostnames.
+    EOS
+  ) do |vals|
+    locations, ip_version = vals
+    raise(ArgumentError, 'Must specify a (set of) location(s)') unless locations
+    raise(ArgumentError, 'Must specify an IP-version') unless ip_version
+
+    Puppet::Parser::Functions.function(:nslookup)
+    require 'ipaddr'
+
+
+    if locations == ''
+      return ''
+    elsif locations.is_a?(String)
+      locations = [ locations ]
+    end
+
+    type = (ip_version == "6" ? 'AAAA' : 'A')
+    out = []
+
+    locations.each { |location|
+      if !(IPAddr.new(location) rescue nil).nil?
+        out << location
+      else
+        out.concat(function_nslookup([ location, type ]))
+      end
+    }
+
+    return out.length > 0 ? out : ''
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ define firewall (
     direction      => $direction,
     order          => $order,
     enable         => $enable,
+    enable_v4      => $enable,
     enable_v6      => $enable_v6
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ define firewall (
   $order          = '',
   $tool           = 'iptables',
   $enable         = true,
-  $enable_v6      = false
+  $enable_v6      = true
   ) {
 
   include firewall::setup

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,8 +29,8 @@ class firewall::params (
     $log_limit       = $iptables::log_limit
     $log_level       = $iptables::log_level
 
-    $enable_v4       = $iptables::bool_enable_v4
-    $enable_v6       = $iptables::bool_enable_v6
+    $enable_v4       = $iptables::enable_v4
+    $enable_v6       = $iptables::enable_v6
     $target          = $iptables::default_target
 
   }

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -124,6 +124,7 @@ define firewall::rule (
   $resolve_failsafe = true,
 
   # Iptables specifics
+  $iptables_table            = 'filter',
   $iptables_chain            = '',
   $iptables_target           = '',
   $iptables_implicit_matches = {},
@@ -212,6 +213,7 @@ define firewall::rule (
     }
 
     iptables::rule { $name:
+      table            => $iptables_table,
       chain            => $chain,
       target           => $real_iptables_target,
       in_interface     => $in_interface,

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -4,6 +4,100 @@
 # Currently only the "iptables" tool is supported, which makes use of
 # Example42's iptables module for host based local firewalling
 #
+# [*source*]
+#   The packets source address (in iptables --source
+#   supported syntax). Can be an array of sources.
+#
+# [*source_v6*]
+#    The packets IPv6 source address. Can be an array of sources.
+#
+# [*destination*]
+#    The packets destination (in iptables --destination
+#    supported syntax). Can be an array of destinations.
+#
+# [*destination_v6*]
+#   The packets IPv6 destination. Can be an array of destinations.
+#
+# [*protocol*]
+#   The transport protocol (tcp,udp,icmp, anything from /etc/protocols )
+#
+# [*port*]
+#   The DESTINATION port
+#
+# [*action*]
+#   Either 'drop', 'deny' or 'accept'
+#
+# [*direction*]
+#   Either 'input', 'output', 'forward'
+#
+# [*order*]
+#   The CONCAT order where to place your rule.
+#
+# [*in_interface*]
+#   The inbound interface for the rule
+#
+# [*out_interface*]
+#   The outbound interface for the rule
+#
+# [*log*]
+#    Bool. To log the traffic matched by this rule. Default false
+#
+# [*log_prefix*]
+#   Prefix for the lines logged
+#
+# [*log_limit*]
+#   Limit the logging based on iptables --limit directive
+#
+# [*log_level*]
+#   The Iptables log level directive
+#
+# [*enable*]
+#   To enable, or not to enable. That's the question.
+#
+# [*enable_v4*]
+#   Enable IPv4. Defaults to true
+#
+# [*enable_v6*]
+#   Enable IPv6. Defaults to true.
+#
+# [*debug*]
+#   Enable debugging.
+#
+# [*resolve_locations*]
+#   Resolve any hostnames that are in $source, $source_v6,
+#   $destination and $destination_v6. This means that:
+#   V4: [ '127.0.0.1', 'www.example42.com' ]
+#   Becomes: [ '127.0.0.1', '176.9.65.210' ]
+#
+#   V6: [ '::1', 'www.example42.com' ]
+#   Becomes: [ '::1' ] (example42.com doesn't resolve any AAAA records yet
+#
+# [*resolve_failsafe*]
+#   Bool. Default true. Disable the given IP version if no hosts could be
+#   resolved. Looks at source ip if $direction == input, destination ip if
+#   $direction == output. Does nothing with forward traffic (yet).
+#
+# [*iptables_chain*]
+#   The iptables chain to work on (default INPUT).
+#   Write it UPPERCASE coherently with iptables syntax
+#
+# [*iptables_implicit_matches*]
+#   An hashmap with implicit match criteria with the possibility to negate
+#   specific matches:
+#   { 'dport' => 80, 'tcp-flags' => 'ACK', 'invert' => [ 'tcp-flags'] }
+#   Results in: --dport 80 --tcp-flags ! ACK
+#
+#   See here for a full list of possible implicit criteria:
+#     http://www.iptables.info/en/iptables-matches.html#IMPLICITMATCHES
+#
+# [*iptables_explicit_matches*]
+#   An hashmap with explicit match criteria with the possibility to negate
+#   specific matches:
+#   { 'icmp' => { 'icmp-type' => 8 }, 'hashlimit' => { 'hashlimit' => '1000/sec } }
+#   Results in: -m icmp --icmp-type 8 -m hashlimit --hashlimit 1000/sec
+#
+# [*iptables_target_options*]
+#   A hashmap with key=>values of options to be appended after the target.
 
 define firewall::rule (
   $source           = '',
@@ -26,6 +120,8 @@ define firewall::rule (
   $enable_v4        = $firewall::setup::enable_v4,
   $enable_v6        = $firewall::setup::enable_v6,
   $debug            = false,
+  $resolve_locations = true,
+  $resolve_failsafe = true,
 
   # Iptables specifics
   $iptables_chain            = '',
@@ -36,6 +132,51 @@ define firewall::rule (
 ) {
 
   include firewall::setup
+  
+  if any2bool($enable_v4) and any2bool($resolve_locations) {
+    $real_source = firewall_resolve_locations($source, '4')
+    $real_destination = firewall_resolve_locations($destination, '4')
+    $real_enable_v4 = any2bool($resolve_failsafe) ? {
+      false => $enable_v4,
+      default => 
+         (
+           (!('0' != inline_template('<%=@source.length %>') and 
+           '0' == inline_template('<%=@real_source.length %>')) and
+           $direction == 'input')
+          ) or (
+           (!('0' != inline_template('<%=@destination.length %>') and 
+           '0' == inline_template('<%=@real_destination.length %>')) and
+           $direction == 'output')
+          )
+    }
+  } else {
+    $real_source      = $source
+    $real_destination = $destination
+    $real_enable_v4   = $enable_v4
+  }
+
+  if any2bool($enable_v6) and any2bool($resolve_locations) {
+    $real_source_v6 = firewall_resolve_locations($source_v6, '6')
+    $real_destination_v6 = firewall_resolve_locations($destination_v6, '6')
+    $real_enable_v6 = any2bool($resolve_failsafe) ? {
+      false => $enable_v6,
+      default => 
+         (
+           (!('0' != inline_template('<%=@source_v6.length %>') and 
+           '0' == inline_template('<%=@real_source_v6.length %>')) and
+           $direction == 'input')
+          ) or (
+           (!('0' != inline_template('<%=@destination_v6.length %>') and 
+           '0' == inline_template('<%=@real_destination_v6.length %>')) and
+           $direction == 'output')
+          )
+    }
+    
+  } else {
+    $real_source_v6      = $source_v6
+    $real_destination_v6 = $destination_v6
+    $real_enable_v6      = $enable_v6
+  }
 
   if ($firewall::setup::rule_class =~ /firewall::rule::iptables/) {
 
@@ -64,10 +205,10 @@ define firewall::rule (
       target           => $firewall::setup::iptables_targets[$action],
       in_interface     => $in_interface,
       out_interface    => $out_interface,
-      source           => $source,
-      source_v6        => $source_v6,
-      destination      => $destination,
-      destination_v6   => $destination_v6,
+      source           => $real_source,
+      source_v6        => $real_source_v6,
+      destination      => $real_destination,
+      destination_v6   => $real_destination_v6,
       protocol         => $protocol,
       port             => $port,
       order            => $real_order,
@@ -77,8 +218,8 @@ define firewall::rule (
       log_limit        => $log_limit,
       log_level        => $log_level,
       enable           => $enable,
-      enable_v4        => $enable_v4,
-      enable_v6        => $enable_v6,
+      enable_v4        => $real_enable_v4,
+      enable_v6        => $real_enable_v6,
       debug            => $debug,
       implicit_matches => $iptables_implicit_matches,
       explicit_matches => $iptables_explicit_matches,

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -174,7 +174,7 @@ define firewall::rule (
            (!('0' != inline_template('<%=@destination_v6.length %>') and 
            '0' == inline_template('<%=@real_destination_v6.length %>')) and
            $real_direction == 'output')
-          )
+          ) or ($real_direction != 'input' and $real_direction != 'output' ) # This line needs changing. Some time
     }
     
   } else {

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -125,6 +125,7 @@ define firewall::rule (
 
   # Iptables specifics
   $iptables_chain            = '',
+  $iptables_target           = '',
   $iptables_implicit_matches = {},
   $iptables_explicit_matches = {},
   $iptables_target_options   = {},
@@ -204,10 +205,15 @@ define firewall::rule (
       ''      => $firewall::setup::iptables_chains[$real_direction],
       default => $iptables_chain
     }
+    
+    $real_iptables_target = $iptables_target ? {
+      ''      => $firewall::setup::iptables_targets[$action],
+      default => $iptables_target
+    }
 
     iptables::rule { $name:
       chain            => $chain,
-      target           => $firewall::setup::iptables_targets[$action],
+      target           => $real_iptables_target,
       in_interface     => $in_interface,
       out_interface    => $out_interface,
       source           => $real_source,


### PR DESCRIPTION
The following two scenarios are now possible:
   Implicit resolving:

```
  firewall::rule { "name":
    source          => "$::fqdn",
    destination     => 'example42.com',
    destination_v6  => [ 'example42.com', 'he.net' ],
    protocol        => $proto,
    port            => $port,
    action          => 'allow',
    direction       => 'output',
  }
```

  Explicit Resolving:

```
   $dns_info = firewall_dns_info('www.gmail.com')

  firewall { "name":
    destination       => $dns_info['ip_v4'],
    destination_v6    => $dns_info['ip_v6'],
    protocol          => $proto,
    port              => $port,
    action            => 'allow',
    direction         => 'output',
    resolve_locations => false,
    enable            => $dns_info['enable_v4'],
    enable_v6         => $dns_info['enable_v6'],
  }
```
